### PR TITLE
Apply minor optimizations

### DIFF
--- a/src/core/udata.S
+++ b/src/core/udata.S
@@ -39,6 +39,10 @@ _ledmtx_font_mask	res 1	; The bitmask of a character
 _ledmtx_config_width	res 1	; The width of the framebuffer (pixels)
 _ledmtx_config_height	res 1	; The height of the framebuffer (pixels)
 _ledmtx_config_stride	res 1	; The length of a scanline (bytes)
+
+; These are not required to be in the Access RAM as they are always accessed
+; using `movff`.
+.udata_ledmtx		udata
 _ledmtx_config_tmr0h	res 1	; The value that is preloaded in TMR0H
 _ledmtx_config_tmr0l	res 1	; The value that is preloaded in TMR0L
 _ledmtx_config_t0con	res 1	; The T0CON that was used in the call to `ledmtx_init()`

--- a/src/driver/libledmtx_r393c164.S
+++ b/src/driver/libledmtx_r393c164.S
@@ -39,11 +39,10 @@ _ledmtx_driver_row	res	1
 ;; Output the 1's complement of `register<bit>` to the LEDMTX_R393C164_CDAT pin,
 ;; after which the LEDMTX_R393C164_CCLK pin is pulsed.
 OUTBIT	macro	register, bit
-  bcf	LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_CDAT, A	; set CDAT to `~register<bit>`
-  btfss register, bit, A
+  andwf	LEDMTX_R393C164_IOPORT, f, A			; set both `CDAT` and `CCLK` to 0
+  btfss	register, bit, A				; `CDAT = ~register<bit>`
   bsf	LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_CDAT, A	;        _
-  bsf	LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_CCLK, A	; CCLK _| |_
-  bcf	LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_CCLK, A
+  bsf	LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_CCLK, A	; CCLK _|
   endm
 
   code
@@ -64,20 +63,23 @@ _ledmtx_driver_vertrefresh:
   movf		PRODH, w, A
   addwfc	FSR0H, f, A
   movf		POSTDEC0, f, A			;          - 1
-  movf		_ledmtx_config_stride, w, A	; WREG = _ledmtx_config_stride
+  movff		_ledmtx_config_stride, PRODL	; PRODL = _ledmtx_config_stride
 
 ;; Disable row selection temporarily, to avoid glitches while data is shifted out
   bcf		LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_RENA, A
 
+; TODO: control flow may be simplified using `movf` + `bz`, but test fails for some reason
   tstfsz	_ledmtx_driver_row, A		; if (_ledmtx_driver_row == 0)
   bra		@vertrefresh_rclk
   bsf		LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_RRST, A	;	        _
   bcf		LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_RRST, A	;	 RRST _| |_
-  bra		@vertrefresh_loop
+  bra		@vertrefresh_loop_prologue
 @vertrefresh_rclk:
   bsf		LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_RCLK, A	;        _
   bcf		LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_RCLK, A	; RCLK _| |_
 
+@vertrefresh_loop_prologue:
+  movlw		~((1 << LEDMTX_R393C164_CDAT) | (1 << LEDMTX_R393C164_CCLK))	; Setup mask used in OUTBIT
 @vertrefresh_loop:				; `do {`
   OUTBIT	INDF0, 0			; 	shift out *(FSR0)
   OUTBIT	INDF0, 1
@@ -87,7 +89,7 @@ _ledmtx_driver_vertrefresh:
   OUTBIT	INDF0, 5
   OUTBIT	INDF0, 6
   OUTBIT	POSTDEC0, 7
-  decfsz	WREG, w, A			; `} while (--WREG != 0)`
+  decfsz	PRODL, f, A			; `} while (--PRODL != 0)`
   bra		@vertrefresh_loop
 
 ;; Re-enable row selection

--- a/src/modules/perf/getintrtime.S
+++ b/src/modules/perf/getintrtime.S
@@ -39,10 +39,10 @@ _ledmtx_perf_getintrtime:
 ;; at the beginning of the ISR; `_ledmtx_perf_tmr0` is set at the end before the
 ;; `retfie` instruction, thus return (_ledmtx_perf_tmr0
 ;;	- _ledmtx_config_tmr0h:_ledmtx_config_tmr0l)
-  movf		_ledmtx_config_tmr0l, w, A
+  movff		_ledmtx_config_tmr0l, WREG
   subwf		_ledmtx_perf_tmr0+0, w
   movwf		POSTDEC1, A
-  movf		_ledmtx_config_tmr0h, w, A
+  movff		_ledmtx_config_tmr0h, WREG
   subwfb	_ledmtx_perf_tmr0+1, w
   movwf		PRODL, A
   movf		PREINC1, w, A

--- a/src/modules/perf/init.S
+++ b/src/modules/perf/init.S
@@ -45,9 +45,9 @@ _ledmtx_perf_init:
 ;; optimize the ISR.
   setf		_ledmtx_perf_intrtimelimit+0
   setf		_ledmtx_perf_intrtimelimit+1
-  movf		_ledmtx_config_tmr0l, w, A
+  movff		_ledmtx_config_tmr0l, WREG
   subwf		_ledmtx_perf_intrtimelimit+0, f
-  movf		_ledmtx_config_tmr0h, w, A
+  movff		_ledmtx_config_tmr0h, WREG
   subwfb	_ledmtx_perf_intrtimelimit+1, f
   return
 

--- a/tests/modules/perf/getintrtime.S
+++ b/tests/modules/perf/getintrtime.S
@@ -31,9 +31,9 @@ _ledmtx_framebuffer	res 28	; unused, but required to link
 ;; void main(void)
 _main:
   movlw		0xAA
-  movwf		_ledmtx_config_tmr0h, a
+  movff		WREG, _ledmtx_config_tmr0h
   movlw		0xBB
-  movwf		_ledmtx_config_tmr0l, a
+  movff		WREG, _ledmtx_config_tmr0l
   banksel	_ledmtx_perf_tmr0
   movlw		0xDD
   movwf		_ledmtx_perf_tmr0+1

--- a/tests/modules/perf/init.S
+++ b/tests/modules/perf/init.S
@@ -32,9 +32,9 @@ _ledmtx_framebuffer	res 28	; unused, but required to link
 ;; void main(void)
 _main:
   movlw		0xAA
-  movwf		_ledmtx_config_tmr0h, a
+  movff		WREG, _ledmtx_config_tmr0h
   movlw		0xBB
-  movwf		_ledmtx_config_tmr0l, a
+  movff		WREG, _ledmtx_config_tmr0l
 
 ; COM: FIXME: cannot check _ledmtx_perf_tmr0+1 == 0xAA (missing symbol)
 ; CHECK: _ledmtx_perf_tmr0 = 0xbb


### PR DESCRIPTION
This PR applies minor optimizations affecting the `r393c164` driver and the use of access RAM, specifically:
- Make the `OUTBIT` macro 1 cycle faster.  The driver now requires one less instruction per column, i.e. 32 less cycles for a framebuffer whose width is 32.
- Use 3 bytes less in the Access RAM.