### PR TITLE
Apply optimizations to `ledmtx_scroll_(l|r)`

### DIFF
--- a/src/core/scroll_l.S
+++ b/src/core/scroll_l.S
@@ -76,17 +76,15 @@ _ledmtx_scroll_l:
 @scroll_l_loop:
   movff		r0x00, PRODH		; PRODH = (w >> 3)
   bcf		STATUS, C, A
-  clrf		WREG, A
 
 @scroll_l_shift:			; `for (; PRODH !=0; --PRODH) {`
-  rlcf		PLUSW0, f, A		; *(FSR0 + WREG) = *(FSR0 + WREG) << 1
-  decfsz	WREG, w, A		; `decf` affects Carry bit; `decfsz` does not
-  ; nop
+  rlcf		POSTDEC0, f, A		; *(FSR0--) = *(FSR0) << 1
   decfsz	PRODH, f, A
   bra		@scroll_l_shift		; `}`
 
-;;; FSR0 += _ledmtx_config_stride
+;;; FSR0 += _ledmtx_config_stride + r0x00
   movf		_ledmtx_config_stride, w, A
+  addwf		r0x00, w, A
   addwf		FSR0L, f, A
   btfsc		STATUS, C, A
   incf		FSR0H, f, A

--- a/src/core/scroll_r.S
+++ b/src/core/scroll_r.S
@@ -72,17 +72,15 @@ _ledmtx_scroll_r:
 @scroll_r_loop:
   movff		r0x00, PRODH		; PRODH = (w >> 3)
   bcf		STATUS, C, A
-  clrf		WREG, A
 
 @scroll_r_shift:			; `for (; PRODH !=0; --PRODH) {`
-  rrcf		PLUSW0, f, A		; *(FSR0 + WREG) = *(FSR0 + WREG) >> 1
-  incfsz	WREG, w, A		; `incf` affects Carry bit; `incfsz` does not
-  ; nop
+  rrcf		POSTINC0, f, A		; *(FSR0++) = *(FSR0) >> 1
   decfsz	PRODH, f, A		; `}`
   bra		@scroll_r_shift
 
-;;; FSR0 += _ledmtx_config_stride
-  movf		_ledmtx_config_stride, w, A
+;;; FSR0 += _ledmtx_config_stride - r0x00
+  movf		r0x00, w, A
+  subwf		_ledmtx_config_stride, w, A
   addwf		FSR0L, f, A
   btfsc		STATUS, C, A
   incf		FSR0H, f, A


### PR DESCRIPTION
Optimize the inner loop of `ledmtx_scroll_(l|r)` so that it takes only 4 cycles per iteration.