### PR TITLE
Simplify installation via `INSTALL_PREFIX` variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
+SRCDIR = $(realpath ./)/src
+include $(SRCDIR)/make.mk
+
 SUBDIRS = include src support
 
 all clean install:
 	list='$(SUBDIRS)'; for subdir in $$list; do \
 	  echo "Making $@ in $$subdir"; \
-	  (cd $$subdir && $(MAKE) $@); \
+	  (cd $$subdir && $(MAKE) SRCDIR=$(SRCDIR) $@); \
 	done
 
 clean: clean-libledmtx

--- a/README.md
+++ b/README.md
@@ -55,13 +55,9 @@ $ lit tests/
 ```
 
 ## Installing
-To install the library files change to the directory where you extracted libledmtx and run `make install` providing the path to the installation directories as in
+To install required files, change to the directory where you cloned libledmtx and run `make install` setting `INSTALL_PREFIX` to the destination directory, e.g.
 ```bash
-$ make LIBDIR=/path/to/lib INCLUDEDIR=/path/to/include BINDIR=/path/to/bin install
-```
-E.g.,
-```bash
-$ make LIBDIR=$HOME/libledmtx/lib INCLUDEDIR=$HOME/libledmtx/include BINDIR=$HOME/libledmtx/bin install
+$ make INSTALL_PREFIX=$HOME/.local/libledmtx/ install
 ```
 
 ## Hardware

--- a/doc/Makefile.template
+++ b/doc/Makefile.template
@@ -6,9 +6,12 @@ P18FXXX = 18f452
 OSC_HZ = 8000000
 VIDEO_MODE_DESC = 32 7 7 50
 
-LIBDIR = 
-INCLUDEDIR = 
-BINDIR = 
+# Set `INSTALL_PREFIX` to actual libledmtx installation directory.
+INSTALL_PREFIX = /path/to/libledmtx_install.d/
+
+LIBDIR = $(INSTALL_PREFIX)/lib/
+INCLUDEDIR = $(INSTALL_PREFIX)/include/
+BINDIR = $(INSTALL_PREFIX)/bin/
 
 DRIVER = r393c164
 # Update list of libledmtx objects to link, if needed

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,5 @@
 include make.mk
 
-SRCDIR = .
 OBJECTS = libledmtx_stdio.o
 SUBDIRS = core driver font modules
 

--- a/src/make.mk
+++ b/src/make.mk
@@ -1,9 +1,16 @@
 # Target device
 P18FXXX = 18f452
 
+ifdef INSTALL_PREFIX
+LIBDIR = $(INSTALL_PREFIX)/lib/
+INCLUDEDIR = $(INSTALL_PREFIX)/include/
+BINDIR = $(INSTALL_PREFIX)/bin/
+else
+INCLUDEDIR ?= $(SRCDIR)/../include
+endif
+
 GPLIB = gplib
 AS = gpasm
-INCLUDEDIR ?= $(SRCDIR)/../include
 ASFLAGS = -I$(SRCDIR) -I$(INCLUDEDIR) -p $(P18FXXX) -w 0
 
 # Optional features

--- a/support/ledmtx_modegen/Makefile
+++ b/support/ledmtx_modegen/Makefile
@@ -1,5 +1,6 @@
-CFLAGS = -Wall -Wpedantic -O2 -std=c++20
+include $(SRCDIR)/make.mk
 
+CFLAGS = -Wall -Wpedantic -O2 -std=c++20
 OBJECTS = ledmtx_modegen.o
 
 all: ledmtx_modegen


### PR DESCRIPTION
This pull request introduces the `INSTALL_PREFIX` make variable, thus simplifying the installation instructions.  See updated README.md.