### PR TITLE
r393c164_32x8: fix defects in KiCad schematic / PCB

### DIFF
--- a/hardware/kicad/r393c164_32x8/r393c164_32x8.kicad_pcb
+++ b/hardware/kicad/r393c164_32x8/r393c164_32x8.kicad_pcb
@@ -7779,7 +7779,7 @@
 				)
 			)
 		)
-		(property "Value" "74HC164"
+		(property "Value" "74HC164 / CD54ACT164"
 			(at 0 5.28 90)
 			(layer "F.Fab")
 			(uuid "f22123ce-89e2-4764-a349-bfd51b32e9db")
@@ -12403,7 +12403,7 @@
 				)
 			)
 		)
-		(property "Value" "74HC164"
+		(property "Value" "74HC164 / CD54ACT164"
 			(at 0 5.28 90)
 			(layer "F.Fab")
 			(uuid "9ee4da37-4eb2-4d67-b94b-fc65502159cc")
@@ -13007,7 +13007,7 @@
 				)
 			)
 		)
-		(property "Value" "74LS393"
+		(property "Value" "74HC393"
 			(at 0 5.28 0)
 			(layer "F.Fab")
 			(uuid "14b1e3fc-33c0-40c2-b4bf-70bebaa56141")
@@ -14698,7 +14698,7 @@
 				)
 			)
 		)
-		(property "Value" "74HC164"
+		(property "Value" "74HC164 / CD54ACT164"
 			(at 0 5.28 90)
 			(layer "F.Fab")
 			(uuid "f586b08b-e43a-47d4-9429-6e425cec9fad")
@@ -16392,7 +16392,7 @@
 				)
 			)
 		)
-		(property "Value" "74HC164"
+		(property "Value" "74HC164 / CD54ACT164"
 			(at 0 5.28 90)
 			(layer "F.Fab")
 			(uuid "9c7fefd5-2921-4164-bd76-6d33f50bd436")

--- a/hardware/kicad/r393c164_32x8/r393c164_32x8.kicad_prl
+++ b/hardware/kicad/r393c164_32x8/r393c164_32x8.kicad_prl
@@ -1,6 +1,6 @@
 {
   "board": {
-    "active_layer": 5,
+    "active_layer": 0,
     "active_layer_preset": "",
     "auto_track_width": false,
     "hidden_netclasses": [],

--- a/hardware/kicad/r393c164_32x8/r393c164_32x8.kicad_sch
+++ b/hardware/kicad/r393c164_32x8/r393c164_32x8.kicad_sch
@@ -3193,6 +3193,12 @@
 		(uuid "b295f7af-e488-4614-850c-e0ee75970d24")
 	)
 	(junction
+		(at 38.1 106.68)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bbea9f21-c10d-4de0-9e1f-d27f05a6b4b8")
+	)
+	(junction
 		(at 110.49 129.54)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -3257,12 +3263,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "e54649cf-58c2-4274-bc6d-96b2d4938325")
-	)
-	(junction
-		(at 38.1 105.41)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "f451a429-51e7-47f8-8973-7baf79e1624c")
 	)
 	(junction
 		(at 120.65 114.3)
@@ -3586,7 +3586,7 @@
 	)
 	(wire
 		(pts
-			(xy 35.56 102.87) (xy 35.56 105.41)
+			(xy 35.56 102.87) (xy 35.56 106.68)
 		)
 		(stroke
 			(width 0)
@@ -4136,6 +4136,16 @@
 	)
 	(wire
 		(pts
+			(xy 38.1 95.25) (xy 38.1 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "401145c5-5807-4333-b166-5eeb7e6116e9")
+	)
+	(wire
+		(pts
 			(xy 120.65 104.14) (xy 132.08 104.14)
 		)
 		(stroke
@@ -4513,16 +4523,6 @@
 			(type default)
 		)
 		(uuid "55c5484d-d83c-4039-934a-22ec5617fdc5")
-	)
-	(wire
-		(pts
-			(xy 38.1 106.68) (xy 38.1 105.41)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "5710fbc2-2765-45ef-ac99-c13290a9e2ac")
 	)
 	(wire
 		(pts
@@ -6436,7 +6436,7 @@
 	)
 	(wire
 		(pts
-			(xy 35.56 105.41) (xy 38.1 105.41)
+			(xy 35.56 106.68) (xy 38.1 106.68)
 		)
 		(stroke
 			(width 0)
@@ -7363,16 +7363,6 @@
 			(type default)
 		)
 		(uuid "f949b72d-7a35-4860-a78a-dd31ca09ace7")
-	)
-	(wire
-		(pts
-			(xy 38.1 95.25) (xy 38.1 105.41)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f98f669c-fc76-48a4-aa34-5284df08fb64")
 	)
 	(wire
 		(pts
@@ -9525,7 +9515,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "74HC164"
+		(property "Value" "74HC164 / CD54ACT164"
 			(at 164.7033 116.84 0)
 			(effects
 				(font
@@ -9702,7 +9692,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "74HC164"
+		(property "Value" "74HC164 / CD54ACT164"
 			(at 122.7933 116.84 0)
 			(effects
 				(font
@@ -10751,7 +10741,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "74HC164"
+		(property "Value" "74HC164 / CD54ACT164"
 			(at 248.5233 116.84 0)
 			(effects
 				(font
@@ -11489,7 +11479,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "74LS393"
+		(property "Value" "74HC393"
 			(at 31.75 137.1599 90)
 			(effects
 				(font
@@ -11842,7 +11832,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "74LS393"
+		(property "Value" "74HC393"
 			(at 54.61 137.1599 90)
 			(effects
 				(font
@@ -12288,7 +12278,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "74HC164"
+		(property "Value" "74HC164 / CD54ACT164"
 			(at 206.6133 116.84 0)
 			(effects
 				(font
@@ -13950,7 +13940,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "74LS393"
+		(property "Value" "74HC393"
 			(at 74.93 137.1599 0)
 			(effects
 				(font


### PR DESCRIPTION
Fix a couple of defects found while doing review of schematic / PCB layout:

- Suggest CD54ACT164 as a (better) alternative to the 74HC164, given that its datasheet specifies 100mA as the maximum source / sink current.

- 74LS393 should really be 74HC393.