### PR TITLE
[scrollstr] Allow for user-specified height of the scroll region

### DIFF
--- a/examples/scrollstr32x7/scrollstr32x7.c
+++ b/examples/scrollstr32x7/scrollstr32x7.c
@@ -47,7 +47,7 @@ void main(void) {
               LEDMTX__DEFAULT_TMR0L, LEDMTX__DEFAULT_T0CON);
   ledmtx_setfont(ledmtx_font5x7);
 
-  LEDMTX_SCROLLSTR_SET(s0, 2, 0, 0, 32, (__data char *)str,
+  LEDMTX_SCROLLSTR_SET(s0, 2, 0, 0, 32, ledmtx_font_sz_h, (__data char *)str,
                        ledmtx_scrollstr_step, ledmtx_scrollstr_reset);
   ledmtx_scrollstr_start(&s0);
 }

--- a/include/ledmtx_scrollstr.h
+++ b/include/ledmtx_scrollstr.h
@@ -32,6 +32,7 @@ struct ledmtx_scrollstr_desc {
   unsigned char counter;
   unsigned char timeout;        ///< Interval between steps
   __far void (*step)(__data struct ledmtx_scrollstr_desc *);   ///< The step function
+  unsigned char h;              ///< Height of the region; usually just `ledmtx_font_sz_h`
   unsigned char w;              ///< Width of the region
   unsigned char y;              ///< The (y) coordinate of the region
   unsigned char x;              ///< The (x) coordinate of the region
@@ -45,10 +46,11 @@ struct ledmtx_scrollstr_desc {
 
 // FIXME: this should probably be turned into a function instead.
 /// Helper to initialize a `struct ledmtx_scrollstr_desc`
-#define LEDMTX_SCROLLSTR_SET(desc, _timeout, _x, _y, _w, _str, _step, _end) \
+#define LEDMTX_SCROLLSTR_SET(desc, _timeout, _x, _y, _w, _h, _str, _step, _end) \
 do {                                                                        \
   (desc).counter = (desc).timeout = _timeout;                               \
   (desc).step = _step;                                                      \
+  (desc).h = _h;                                                            \
   (desc).w = _w;                                                            \
   (desc).y = _y;                                                            \
   (desc).x = _x;                                                            \

--- a/src/modules/scrollstr/reset.S
+++ b/src/modules/scrollstr/reset.S
@@ -37,7 +37,7 @@ _ledmtx_scrollstr_reset:
   movlw		1		; counter = timeout
   movff		PLUSW0, INDF0
 
-  movlw		10
+  movlw		11
   addwf		FSR0L, f, A
   btfsc		STATUS, C, A
   incf		FSR0H, f, A

--- a/src/modules/scrollstr/start.S
+++ b/src/modules/scrollstr/start.S
@@ -55,7 +55,7 @@ _ledmtx_scrollstr_start:
   movff		PLUSW1, FSR0H			; FSR0 = desc
   movlw		2
   movff		PLUSW1, FSR0L
-  movlw		16				; *(FRS0 + 16) = WREG
+  movlw		17				; *(FRS0 + 17) = WREG
   movff		PREINC1, PLUSW0
 
   movf		INDF1, w, A			; _ledmtx_scrollstr_bitmap |= WREG

--- a/src/modules/scrollstr/step.S
+++ b/src/modules/scrollstr/step.S
@@ -49,7 +49,7 @@ _ledmtx_scrollstr_step:
   incf		FSR2H, f, A
 
 ;; Call `ledmtx_scroll_l()`
-  movff		_ledmtx_font_sz_h, POSTDEC1
+  movff		POSTINC2, POSTDEC1
   movff		POSTINC2, POSTDEC1
   movff		POSTINC2, POSTDEC1
   movff		POSTINC2, POSTDEC1

--- a/src/modules/scrollstr/stop.S
+++ b/src/modules/scrollstr/stop.S
@@ -36,11 +36,11 @@ _ledmtx_scrollstr_stop:
   movlw		2
   movff		PLUSW1, FSR0H
 
-  movlw		16				; _ledmtx_scrollstr_bitmap &= ~*(FSR0 + 16)
+  movlw		17			; _ledmtx_scrollstr_bitmap &= ~*(FSR0 + 17)
   movf		PLUSW0, w, A
   xorlw		0xff
   andwf		_ledmtx_scrollstr_bitmap, f, A
-  movlw		16				; *(FSR0+16) = 0
+  movlw		17				; *(FSR0+17) = 0
   clrf		PLUSW0, A
   return
 

--- a/tests/modules/scrollstr/reset.S
+++ b/tests/modules/scrollstr/reset.S
@@ -51,11 +51,11 @@ _main:
   lfsr		0, _scrollstr_desc_1
   movlw		0
   movff		r0x00, PLUSW0	; counter
-  movlw		10
-  movff		r0x00, PLUSW0	; i
   movlw		11
-  movff		r0x00, PLUSW0	; charoff
+  movff		r0x00, PLUSW0	; i
   movlw		12
+  movff		r0x00, PLUSW0	; charoff
+  movlw		13
   movff		r0x00, PLUSW0	; mask
 
   movlw		high(_scrollstr_desc_1)
@@ -73,11 +73,11 @@ _main:
   lfsr		0, _scrollstr_desc_1
   movlw		0
   movff		PLUSW0, r0x00	; counter
-  movlw		10
-  movff		PLUSW0, r0x01	; i
   movlw		11
-  movff		PLUSW0, r0x02	; charoff
+  movff		PLUSW0, r0x01	; i
   movlw		12
+  movff		PLUSW0, r0x02	; charoff
+  movlw		13
   movff		PLUSW0, r0x03	; mask
 
   bcf		RCON, PD, a	; hits breakpoint set by `break w (rcon & 0x04) = 0x00`

--- a/tests/modules/scrollstr/scrollstr_desc.inc
+++ b/tests/modules/scrollstr/scrollstr_desc.inc
@@ -12,6 +12,7 @@ _scrollstr_desc_1	db 0x02			; counter
 			db low(_test_stub_step)	; step
 			db high(_test_stub_step)
 			db upper(_test_stub_step)
+			db 7			; height
 			db 16			; width
 			db 0			; y
 			db 0			; x
@@ -30,6 +31,7 @@ _scrollstr_desc_2	db 0x02			; counter
 			db low(_test_stub_step)	; step
 			db high(_test_stub_step)
 			db upper(_test_stub_step)
+			db 7			; height
 			db 16			; width
 			db 0			; y
 			db 16			; x

--- a/tests/modules/scrollstr/start_stop.S
+++ b/tests/modules/scrollstr/start_stop.S
@@ -104,10 +104,10 @@ _main:
   movwf		r0x03, a
 ; COM: Check the `bitmap_mask` member on both descriptors
   lfsr		0, _scrollstr_desc_1
-  movlw		16
+  movlw		17
   movff		PLUSW0,	PRODH	; bitmap_mask
   lfsr		0, _scrollstr_desc_2
-  movlw		16
+  movlw		17
   movff		PLUSW0,	PRODL	; bitmap_mask
   bcf		RCON, PD, a	; hits breakpoint set by `break w (rcon & 0x04) = 0x00`
 

--- a/tests/sdcc/scrollstr.c
+++ b/tests/sdcc/scrollstr.c
@@ -36,30 +36,28 @@ END_DEF
 // The ISR for Timer 0.  In this example, in addition to the vertical refresh
 // routine, `ledmtx_scrollstr_interrupt()` is called to perform the asynchronous
 // text scroll actions.
-SIGHANDLERNAKED(_tmr0_handler)
-{
+SIGHANDLERNAKED(_tmr0_handler) {
   LEDMTX_BEGIN_ISR
-    LEDMTX_BEGIN_R0
-      ledmtx_scrollstr_interrupt();
-    LEDMTX_END_R0
-    LEDMTX_VERTREFRESH
+  LEDMTX_BEGIN_R0
+  ledmtx_scrollstr_interrupt();
+  LEDMTX_END_R0
+  LEDMTX_VERTREFRESH
   LEDMTX_END_ISR
 }
 
 char str[] = "scrollstr32x7: using r393c164 driver to refresh a 32x7 display";
 
-void main(void)
-{
+void main(void) {
   struct ledmtx_scrollstr_desc s0;
-  
+
   TRISA = 0xC0;
   ADCON1 = 0x0F;
-  
+
   ledmtx_init(LEDMTX_INIT_CLEAR | LEDMTX_INIT_TMR0, 32, 7, 0xe9, 0xae, 0x88);
   ledmtx_setfont(ledmtx_font5x7);
-  
-  LEDMTX_SCROLLSTR_SET(s0, 2, 0, 0, 32, (__data char*)str,
-		       ledmtx_scrollstr_step, ledmtx_scrollstr_reset);
+
+  LEDMTX_SCROLLSTR_SET(s0, 2, 0, 0, 32, ledmtx_font_sz_h, (__data char *)str,
+                       ledmtx_scrollstr_step, ledmtx_scrollstr_reset);
   ledmtx_scrollstr_start(&s0);
 
   // COM: Expected framebuffer state after 40 steps


### PR DESCRIPTION
This pull request introduces support for user-specified height of the scroll region.  This is useful, e.g. in case the current font height is actually smaller than the intended region.

This is a (slightly) breaking change.