### PR TITLE
[core] `ledmtx_setviewport()`: fix annoying blink after changing viewport

### DIFF
--- a/src/core/setviewport.S
+++ b/src/core/setviewport.S
@@ -31,7 +31,7 @@
   extern _ledmtx_viewport_xoff
   extern _ledmtx_viewport_stride
 
-  extern _ledmtx_driver_init
+  extern _ledmtx_driver_viewport_changed
 
   global _ledmtx_setviewport
 
@@ -77,7 +77,7 @@ _ledmtx_setviewport:
   andlw		0x1f
   movwf		_ledmtx_viewport_stride, A
 
-  call		_ledmtx_driver_init
+  call		_ledmtx_driver_viewport_changed
   bsf		INTCON, GIE, A
   retlw		1
 @invalid_value:

--- a/src/driver/libledmtx_r393c164.S
+++ b/src/driver/libledmtx_r393c164.S
@@ -1,7 +1,7 @@
 ;
 ; libledmtx_r393c164.S - libledmtx 'r393c164' display hardware driver
 ;
-; Copyright (C) 2011, 2023  Javier Lopez-Gomez
+; Copyright (C) 2011-2025  Javier Lopez-Gomez
 ;
 ; This program is free software; you can redistribute it and/or modify
 ; it under the terms of the GNU Library General Public License as published by
@@ -31,6 +31,7 @@
 
   global _ledmtx_driver_row
   global _ledmtx_driver_init
+  global _ledmtx_driver_viewport_changed
   global _ledmtx_driver_vertrefresh
 
 .udata_acs_ledmtx_driver	udata_acs
@@ -48,6 +49,13 @@ OUTBIT	macro	register, bit
   code
 _ledmtx_driver_init:
   clrf _ledmtx_driver_row, A
+  return
+
+;; The viewport has changed; reset `_ledmtx_driver_row` only if needed.
+_ledmtx_driver_viewport_changed:
+  movf		_ledmtx_viewport_height, w, A
+  cpfslt	_ledmtx_driver_row, A
+  clrf		_ledmtx_driver_row, A
   return
 
 ;; The display is multiplexed, i.e., only one row is driven at a time.
@@ -85,7 +93,7 @@ _ledmtx_driver_vertrefresh:
 
   incf		_ledmtx_driver_row, f, A	; _ledmtx_driver_row++
   movf		_ledmtx_viewport_height, w, A
-  cpfslt	_ledmtx_driver_row, A		; if (_ledmtx_driver_row == _ledmtx_viewport_height)
+  cpfslt	_ledmtx_driver_row, A		; if (_ledmtx_driver_row >= _ledmtx_viewport_height)
   clrf		_ledmtx_driver_row, A		; 	_ledmtx_driver_row = 0
   return
 

--- a/tests/core/setviewport.S
+++ b/tests/core/setviewport.S
@@ -22,6 +22,7 @@
 
   global _ledmtx_framebuffer
   global _ledmtx_driver_init
+  global _ledmtx_driver_viewport_changed
   global _main
   global _stack_end
 
@@ -33,6 +34,9 @@ _ledmtx_framebuffer	res 28	; unused, but required to link
 
   code
 _ledmtx_driver_init:
+  return
+
+_ledmtx_driver_viewport_changed:
   return
 
 ;; void test_inval(void)


### PR DESCRIPTION
`ledmtx_setviewport()` should reset current scanline to 0 only if it lies outside of the new user-defined viewport.  To that end, drivers must implement the `_ledmtx_driver_viewport_changed` subroutine, which is called by `ledmtx_setviewport()` after a viewport change.

The aforementioned subroutine must be implemented by all drivers, even if it is just a no-op.