### PR TITLE
[r393c164]  Add experimental software-based PWM support

### DIFF
--- a/doc/ledmtx_r393c164.inc.template
+++ b/doc/ledmtx_r393c164.inc.template
@@ -1,0 +1,33 @@
+  list
+; ledmtx_r393c164.inc.template	template config for the `r393c164` driver
+  nolist
+
+LEDMTX_R393C164_IOPORT	equ	PORTA
+LEDMTX_R393C164_RCLK	equ	RA0
+LEDMTX_R393C164_RRST	equ	RA1
+LEDMTX_R393C164_RENA	equ	RA2
+LEDMTX_R393C164_CCLK	equ	RA3
+LEDMTX_R393C164_CDAT	equ	RA4
+
+; Uncomment to enable experimental software-based PWM for brightness adjustment
+; (requires an additional timer module; defaults to Timer3).
+; #define LEDMTX_R393C164_E_SOFTPWM 1
+
+#ifdef LEDMTX_R393C164_E_SOFTPWM
+  global ___ledmtx_r393c164_E_softpwm_tmr3
+.udata_ledmtx_driver	udata
+___ledmtx_r393c164_E_softpwm_tmr3	res	2
+
+LEDMTX_R393C164_E_SOFTPWM_DUTY_BEGIN	macro
+  movff	___ledmtx_r393c164_E_softpwm_tmr3+1, TMR3H
+  movff	___ledmtx_r393c164_E_softpwm_tmr3+0, TMR3L
+  bsf		T3CON, TMR3ON, A
+  endm
+
+LEDMTX_R393C164_E_SOFTPWM_DUTY_END	macro
+  bcf		PIR2, TMR3IF, A
+  bcf		LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_RENA, A
+  bcf		T3CON, TMR3ON, A
+  retfie
+  endm
+#endif

--- a/src/driver/libledmtx_r393c164.S
+++ b/src/driver/libledmtx_r393c164.S
@@ -1,7 +1,7 @@
 ;
 ; libledmtx_r393c164.S - libledmtx 'r393c164' display hardware driver
 ;
-; Copyright (C) 2011-2025  Javier Lopez-Gomez
+; Copyright (C) 2011-2026  Javier Lopez-Gomez
 ;
 ; This program is free software; you can redistribute it and/or modify
 ; it under the terms of the GNU Library General Public License as published by
@@ -32,6 +32,9 @@
   global _ledmtx_driver_row
   global _ledmtx_driver_init
   global _ledmtx_driver_viewport_changed
+#ifdef LEDMTX_R393C164_E_SOFTPWM
+  global ___ledmtx_r393c164_E_softpwm_duty_end
+#endif
   global _ledmtx_driver_vertrefresh
 
 .udata_acs_ledmtx_driver	udata_acs
@@ -58,10 +61,18 @@ _ledmtx_driver_viewport_changed:
   clrf		_ledmtx_driver_row, A
   return
 
+#ifdef LEDMTX_R393C164_E_SOFTPWM
+___ledmtx_r393c164_E_softpwm_duty_end:
+  LEDMTX_R393C164_E_SOFTPWM_DUTY_END
+#endif
+
 ;; The display is multiplexed, i.e., only one row is driven at a time.
 ;; Shift out the (negated) value of all bits in the selected row and advance to
 ;; the next row.  This is usually called as part of a timer ISR.
 _ledmtx_driver_vertrefresh:
+#ifdef LEDMTX_R393C164_E_SOFTPWM
+  LEDMTX_R393C164_E_SOFTPWM_DUTY_BEGIN
+#endif
 ;; Compute the framebuffer address of the start of the next row
   LOAD_BUFADDR_IN_FSR0	_ledmtx_frontbuffer	; FSR0 = _ledmtx_frontbuffer
   AT_END_OF_VIEWPORT_ROW	_ledmtx_driver_row


### PR DESCRIPTION
This pull-request adds experimental software-based PWM support (requires an additional timer module; defaults to Timer3).  User is reponsible for:
- Manually configuring Timer3
- Calling `___ledmtx_r393c164_E_softpwm_duty_end` on Timer3 overflow

`___ledmtx_r393c164_E_softpwm_tmr3` may be adjusted to adjust PWM duty cycle.  In particular, the less the distance to overflow (0xffff), the shorter the PWM duty cycle.